### PR TITLE
Make StarlightBlog work with StarlightImageZoom

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig({
       components: {
         SiteTitle: './src/components/overrides/SiteTitle.astro',
         TableOfContents: './src/components/overrides/TableOfContents.astro',
+        MarkdownContent: "./src/components/overrides/MarkdownContent.astro",
         // Sidebar: './src/components/overrides/Sidebar.astro',
       },
       social: {

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -1,0 +1,8 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import Default from "starlight-blog/overrides/MarkdownContent.astro"
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
+<ImageZoom />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
Hello!

I'm not sure if you are aware of this, but the Starlight Blog is not able to override the MarkdownContent.astro Page, which means that all blog sites dont show author infos and so on...

Fortunately for you, I have implemented a fix in this Pull Request, which should fix this for you...

The reason it doesn't work is the Starlight Image Zoom plugin, which overrides the MarkdownContent.astro file before the Starlight Blog can do it...

Have a nice day, bye!